### PR TITLE
test1

### DIFF
--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -20,7 +20,7 @@ function ThemeProvider({ children }: { children: React.ReactNode }) {
 }
 
 // Custom hooks to access theme state and dispatch
-const useTheme = (): boolean => {
+const useCurrentTheme  = (): boolean => {
   const context = useContext(ThemeContext);
   if (context === undefined) {
     throw new Error('useTheme must be used within a ThemeProvider');


### PR DESCRIPTION
<div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR renames the useTheme hook to useCurrentTheme in the ThemeContext file to improve code clarity. The change enhances readability and maintainability by making the hook's purpose more evident, while preserving the existing functionality. This update contributes to clearer code semantics in the theme management system.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>